### PR TITLE
disable new lint rule on client

### DIFF
--- a/src/client/.eslintrc.js
+++ b/src/client/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+  extends: ['../../.eslintrc.js'],
+  rules: {
+    '@chloe-47/no-set-timeout/no-set-timeout': ['off'],
+  },
+};


### PR DESCRIPTION
setTimeoutSafe is only useful for server code